### PR TITLE
Initial Hydrogen Horizons FCS updates

### DIFF
--- a/back-end/realtime/src/rooms/FCS.ts
+++ b/back-end/realtime/src/rooms/FCS.ts
@@ -1,10 +1,28 @@
 import { Server, Socket } from "socket.io";
-import { FieldControlPacket } from "@toa-lib/models";
+import {FCS_ENDGAME, FCS_FIELD_FAULT, FCS_IDLE, FCS_MATCH_START, FieldControlPacket} from "@toa-lib/models";
 import Room from "./Room.js";
+import Match from "./Match.js";
 
 export default class FCS extends Room {
-  public constructor(server: Server) {
+  public constructor(server: Server, matchRoom: Match) {
     super(server, "fcs");
+
+    matchRoom.localEmitter.on("match:start", () => {
+      this.broadcast().emit("fcs:update", FCS_MATCH_START);
+    });
+
+    matchRoom.localEmitter.on("match:endgame", () => {
+      this.broadcast().emit("fcs:update", FCS_ENDGAME);
+    });
+
+    matchRoom.localEmitter.on("match:end", () => {
+      // TODO(Noah): Placeholder
+      this.broadcast().emit("fcs:update", FCS_IDLE);
+    });
+
+    matchRoom.localEmitter.on("match:abort", () => {
+      this.broadcast().emit("fcs:update", FCS_FIELD_FAULT);
+    })
   }
 
   public initializeEvents(socket: Socket): void {

--- a/back-end/realtime/src/rooms/Rooms.ts
+++ b/back-end/realtime/src/rooms/Rooms.ts
@@ -8,7 +8,7 @@ const roomsMap: Map<string, Room> = new Map();
 
 export function initRooms(server: Server) {
   const matchRoom = new Match(server);
-  const fcsRoom = new FCS(server);
+  const fcsRoom = new FCS(server, matchRoom);
   const frcFMSRoom = new FRCFMS(server);
 
   roomsMap.set(matchRoom.getName(), matchRoom);

--- a/front-end/src/api/SocketProvider.tsx
+++ b/front-end/src/api/SocketProvider.tsx
@@ -1,5 +1,9 @@
 import { createSocket } from '@toa-lib/client';
-import { MatchKey } from '@toa-lib/models';
+import {
+  FCS_ALL_CLEAR,
+  FCS_PREPARE_FIELD,
+  MatchKey
+} from '@toa-lib/models';
 import { Socket } from 'socket.io-client';
 import { useRecoilState } from 'recoil';
 import { socketConnectedAtom } from 'src/stores/NewRecoil';
@@ -64,7 +68,7 @@ export function setDisplays(): void {
 }
 
 export function sendPrepareField(): void {
-  // socket?.emit('fcs:update', LED_PRESTART);
+  socket?.emit('fcs:update', FCS_PREPARE_FIELD);
 }
 
 export function sendStartMatch(): void {
@@ -76,7 +80,7 @@ export async function sendAbortMatch(): Promise<void> {
 }
 
 export async function sendAllClear(): Promise<void> {
-  // socket?.emit('fcs:update', LED_ALLCLEAR);
+  socket?.emit('fcs:update', FCS_ALL_CLEAR);
 }
 
 export async function sendCommitScores(key: MatchKey): Promise<void> {

--- a/lib/models/src/fcs/Packets.ts
+++ b/lib/models/src/fcs/Packets.ts
@@ -38,14 +38,6 @@ export enum BlinkinPattern {
   COLOR_WAVES_RAINBOW = 1275,
 }
 
-export const setLEDPattern = (pulseWidth: number): FieldControlPacket => {
-  const packet = LED_EMPTY;
-  packet.messages[0].parameters.pulsewidth = pulseWidth;
-  packet.messages[1].parameters.pulsewidth = pulseWidth;
-  packet.messages[2].parameters.pulsewidth = pulseWidth;
-  return packet;
-};
-
 export const LED_PRESTART: FieldControlPacket = {
   messages: [
     {
@@ -436,31 +428,6 @@ export const LED_COLOR2_HB_FAST: FieldControlPacket = {
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
         pulsewidth: BlinkinPattern.COLOR_2_HB_FAST
-      }
-    }
-  ]
-};
-export const LED_EMPTY: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL
       }
     }
   ]

--- a/lib/models/src/fcs/Packets.ts
+++ b/lib/models/src/fcs/Packets.ts
@@ -1,8 +1,5 @@
 import { FieldControlPacket } from '../FieldControl.js';
 
-const LEFT_MOTOR_CHANNEL = 0;
-const RIGHT_MOTOR_CHANNEL = 1;
-
 const RED_BLINKIN_CHANNEL = 0;
 const BLUE_BLINKIN_CHANNEL = 1;
 const AUDIENCE_BLINKIN_CHANNEL = 2;
@@ -46,68 +43,6 @@ export const setLEDPattern = (pulseWidth: number): FieldControlPacket => {
   packet.messages[1].parameters.pulsewidth = pulseWidth;
   packet.messages[2].parameters.pulsewidth = pulseWidth;
   return packet;
-};
-export const MOTOR_FORWARD: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'motor',
-      parameters: {
-        port: LEFT_MOTOR_CHANNEL,
-        setpoint: 15000
-      }
-    },
-    {
-      hub: 0,
-      function: 'motor',
-      parameters: {
-        port: RIGHT_MOTOR_CHANNEL,
-        setpoint: -15000
-      }
-    }
-  ]
-};
-
-export const MOTOR_DISABLE: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'motor',
-      parameters: {
-        port: LEFT_MOTOR_CHANNEL,
-        setpoint: 0
-      }
-    },
-    {
-      hub: 0,
-      function: 'motor',
-      parameters: {
-        port: RIGHT_MOTOR_CHANNEL,
-        setpoint: 0
-      }
-    }
-  ]
-};
-
-export const MOTOR_REVERSE: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'motor',
-      parameters: {
-        port: LEFT_MOTOR_CHANNEL,
-        setpoint: -15000
-      }
-    },
-    {
-      hub: 0,
-      function: 'motor',
-      parameters: {
-        port: RIGHT_MOTOR_CHANNEL,
-        setpoint: 15000
-      }
-    }
-  ]
 };
 
 export const LED_PRESTART: FieldControlPacket = {

--- a/lib/models/src/fcs/Packets.ts
+++ b/lib/models/src/fcs/Packets.ts
@@ -4,38 +4,39 @@ const RED_BLINKIN_CHANNEL = 0;
 const BLUE_BLINKIN_CHANNEL = 1;
 const AUDIENCE_BLINKIN_CHANNEL = 2;
 
-export const LED_COLOR_BLACK = 1995;
-export const LED_COLOR_YELLOW = 1845;
-export const LED_COLOR_WHITE = 1965;
-export const LED_COLOR_PURPLE = 1955;
-export const LED_COLOR_GREEN = 1885;
-export const LED_COLOR_RED = 1805;
-export const LED_COLOR_RAINBOW = 1275;
-export const LED_COLOR_FIRE = 1215;
-export const LED_COLOR_1_HB_SLOW = 1515;
-export const LED_COLOR_1_HB_MED = 1525;
-export const LED_COLOR_1_HB_FAST = 1535;
-export const LED_COLOR_2_HB_SLOW = 1615;
-export const LED_COLOR_2_HB_MED = 1625;
-export const LED_COLOR_2_HB_FAST = 1635;
-
-export const LED_COLOR_PINK = 1785;
-export const LED_COLOR_DARK_RED = 1795;
-export const LED_COLOR_RED_ORANGE = 1815;
-export const LED_COLOR_ORANGE = 1825;
-export const LED_COLOR_GOLD = 1835;
-export const LED_COLOR_LAWN_GREEN = 1855;
-export const LED_COLOR_LIME = 1865;
-export const LED_COLOR_DARK_GREEN = 1875;
-export const LED_COLOR_BLUE_GREEN = 1895;
-export const LED_COLOR_AQUA = 1905;
-export const LED_COLOR_SKY_BLUE = 1915;
-export const LED_COLOR_DARK_BLUE = 1925;
-export const LED_COLOR_BLUE = 1935;
-export const LED_COLOR_BLUE_VIOLET = 1945;
-export const LED_COLOR_VIOLET = 1955;
-export const LED_COLOR_GRAY = 1975;
-export const LED_COLOR_DARK_GRAY = 1985;
+export enum BlinkinPattern {
+  COLOR_1_HB_FAST = 1535,
+  COLOR_1_HB_MED = 1525,
+  COLOR_1_HB_SLOW = 1515,
+  COLOR_2_HB_FAST = 1635,
+  COLOR_2_HB_MED = 1625,
+  COLOR_2_HB_SLOW = 1615,
+  COLOR_AQUA = 1905,
+  COLOR_BLACK = 1995,
+  COLOR_BLUE = 1935,
+  COLOR_BLUE_GREEN = 1895,
+  COLOR_BLUE_VIOLET = 1945,
+  COLOR_DARK_BLUE = 1925,
+  COLOR_DARK_GRAY = 1985,
+  COLOR_DARK_GREEN = 1875,
+  COLOR_DARK_RED = 1795,
+  COLOR_FIRE = 1215,
+  COLOR_GOLD = 1835,
+  COLOR_GRAY = 1975,
+  COLOR_GREEN = 1885,
+  COLOR_LAWN_GREEN = 1855,
+  COLOR_LIME = 1865,
+  COLOR_ORANGE = 1825,
+  COLOR_PINK = 1785,
+  COLOR_PURPLE = 1955,
+  COLOR_RED = 1805,
+  COLOR_RED_ORANGE = 1815,
+  COLOR_SKY_BLUE = 1915,
+  COLOR_VIOLET = 1955,
+  COLOR_WHITE = 1965,
+  COLOR_YELLOW = 1845,
+  COLOR_WAVES_RAINBOW = 1275,
+}
 
 export const setLEDPattern = (pulseWidth: number): FieldControlPacket => {
   const packet = LED_EMPTY;
@@ -52,7 +53,7 @@ export const LED_PRESTART: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_YELLOW
+        pulsewidth: BlinkinPattern.COLOR_YELLOW
       }
     },
     {
@@ -60,7 +61,7 @@ export const LED_PRESTART: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_YELLOW
+        pulsewidth: BlinkinPattern.COLOR_YELLOW
       }
     },
     {
@@ -68,7 +69,7 @@ export const LED_PRESTART: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_YELLOW
+        pulsewidth: BlinkinPattern.COLOR_YELLOW
       }
     }
   ]
@@ -80,7 +81,7 @@ export const LED_ALLCLEAR: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_GREEN
+        pulsewidth: BlinkinPattern.COLOR_GREEN
       }
     },
     {
@@ -88,7 +89,7 @@ export const LED_ALLCLEAR: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_GREEN
+        pulsewidth: BlinkinPattern.COLOR_GREEN
       }
     },
     {
@@ -96,7 +97,7 @@ export const LED_ALLCLEAR: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_GREEN
+        pulsewidth: BlinkinPattern.COLOR_GREEN
       }
     }
   ]
@@ -108,7 +109,7 @@ export const LED_FIELDFAULT: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_RED
+        pulsewidth: BlinkinPattern.COLOR_RED
       }
     },
     {
@@ -116,7 +117,7 @@ export const LED_FIELDFAULT: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_RED
+        pulsewidth: BlinkinPattern.COLOR_RED
       }
     },
     {
@@ -124,7 +125,7 @@ export const LED_FIELDFAULT: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_RED
+        pulsewidth: BlinkinPattern.COLOR_RED
       }
     }
   ]
@@ -136,7 +137,7 @@ export const LED_IDLE: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_RAINBOW
+        pulsewidth: BlinkinPattern.COLOR_WAVES_RAINBOW
       }
     },
     {
@@ -144,7 +145,7 @@ export const LED_IDLE: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_RAINBOW
+        pulsewidth: BlinkinPattern.COLOR_WAVES_RAINBOW
       }
     },
     {
@@ -152,7 +153,7 @@ export const LED_IDLE: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_RAINBOW
+        pulsewidth: BlinkinPattern.COLOR_WAVES_RAINBOW
       }
     }
   ]
@@ -164,7 +165,7 @@ export const LED_COUNTDOWN: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_PURPLE
+        pulsewidth: BlinkinPattern.COLOR_PURPLE
       }
     },
     {
@@ -172,7 +173,7 @@ export const LED_COUNTDOWN: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_PURPLE
+        pulsewidth: BlinkinPattern.COLOR_PURPLE
       }
     },
     {
@@ -180,7 +181,7 @@ export const LED_COUNTDOWN: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_PURPLE
+        pulsewidth: BlinkinPattern.COLOR_PURPLE
       }
     }
   ]
@@ -221,7 +222,7 @@ export const LED_CARBON: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_WHITE
+        pulsewidth: BlinkinPattern.COLOR_WHITE
       }
     },
     {
@@ -229,7 +230,7 @@ export const LED_CARBON: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_WHITE
+        pulsewidth: BlinkinPattern.COLOR_WHITE
       }
     },
     {
@@ -237,7 +238,7 @@ export const LED_CARBON: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_WHITE
+        pulsewidth: BlinkinPattern.COLOR_WHITE
       }
     }
   ]
@@ -250,7 +251,7 @@ export const LED_COOPERTITION: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_PURPLE
+        pulsewidth: BlinkinPattern.COLOR_PURPLE
       }
     },
     {
@@ -258,7 +259,7 @@ export const LED_COOPERTITION: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_PURPLE
+        pulsewidth: BlinkinPattern.COLOR_PURPLE
       }
     },
     {
@@ -266,7 +267,7 @@ export const LED_COOPERTITION: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_PURPLE
+        pulsewidth: BlinkinPattern.COLOR_PURPLE
       }
     }
   ]
@@ -278,7 +279,7 @@ export const LED_COLOR1_HB_SLOW: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_1_HB_SLOW
+        pulsewidth: BlinkinPattern.COLOR_1_HB_SLOW
       }
     },
     {
@@ -286,7 +287,7 @@ export const LED_COLOR1_HB_SLOW: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_1_HB_SLOW
+        pulsewidth: BlinkinPattern.COLOR_1_HB_SLOW
       }
     },
     {
@@ -294,7 +295,7 @@ export const LED_COLOR1_HB_SLOW: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_1_HB_SLOW
+        pulsewidth: BlinkinPattern.COLOR_1_HB_SLOW
       }
     }
   ]
@@ -306,7 +307,7 @@ export const LED_COLOR2_HB_SLOW: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_2_HB_SLOW
+        pulsewidth: BlinkinPattern.COLOR_2_HB_SLOW
       }
     },
     {
@@ -314,7 +315,7 @@ export const LED_COLOR2_HB_SLOW: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_2_HB_SLOW
+        pulsewidth: BlinkinPattern.COLOR_2_HB_SLOW
       }
     },
     {
@@ -322,7 +323,7 @@ export const LED_COLOR2_HB_SLOW: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_2_HB_SLOW
+        pulsewidth: BlinkinPattern.COLOR_2_HB_SLOW
       }
     }
   ]
@@ -334,7 +335,7 @@ export const LED_COLOR1_HB_MED: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_1_HB_MED
+        pulsewidth: BlinkinPattern.COLOR_1_HB_MED
       }
     },
     {
@@ -342,7 +343,7 @@ export const LED_COLOR1_HB_MED: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_1_HB_MED
+        pulsewidth: BlinkinPattern.COLOR_1_HB_MED
       }
     },
     {
@@ -350,7 +351,7 @@ export const LED_COLOR1_HB_MED: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_1_HB_MED
+        pulsewidth: BlinkinPattern.COLOR_1_HB_MED
       }
     }
   ]
@@ -362,7 +363,7 @@ export const LED_COLOR2_HB_MED: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_2_HB_MED
+        pulsewidth: BlinkinPattern.COLOR_2_HB_MED
       }
     },
     {
@@ -370,7 +371,7 @@ export const LED_COLOR2_HB_MED: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_2_HB_MED
+        pulsewidth: BlinkinPattern.COLOR_2_HB_MED
       }
     },
     {
@@ -378,7 +379,7 @@ export const LED_COLOR2_HB_MED: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_2_HB_MED
+        pulsewidth: BlinkinPattern.COLOR_2_HB_MED
       }
     }
   ]
@@ -390,7 +391,7 @@ export const LED_COLOR1_HB_FAST: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_1_HB_FAST
+        pulsewidth: BlinkinPattern.COLOR_1_HB_FAST
       }
     },
     {
@@ -398,7 +399,7 @@ export const LED_COLOR1_HB_FAST: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_1_HB_FAST
+        pulsewidth: BlinkinPattern.COLOR_1_HB_FAST
       }
     },
     {
@@ -406,7 +407,7 @@ export const LED_COLOR1_HB_FAST: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_1_HB_FAST
+        pulsewidth: BlinkinPattern.COLOR_1_HB_FAST
       }
     }
   ]
@@ -418,7 +419,7 @@ export const LED_COLOR2_HB_FAST: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_2_HB_FAST
+        pulsewidth: BlinkinPattern.COLOR_2_HB_FAST
       }
     },
     {
@@ -426,7 +427,7 @@ export const LED_COLOR2_HB_FAST: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_2_HB_FAST
+        pulsewidth: BlinkinPattern.COLOR_2_HB_FAST
       }
     },
     {
@@ -434,7 +435,7 @@ export const LED_COLOR2_HB_FAST: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: LED_COLOR_2_HB_FAST
+        pulsewidth: BlinkinPattern.COLOR_2_HB_FAST
       }
     }
   ]

--- a/lib/models/src/fcs/Packets.ts
+++ b/lib/models/src/fcs/Packets.ts
@@ -1,8 +1,113 @@
-import { FieldControlPacket } from '../FieldControl.js';
+import {FieldControlPacket, HubMessage} from '../FieldControl.js';
 
-const RED_BLINKIN_CHANNEL = 0;
-const BLUE_BLINKIN_CHANNEL = 1;
-const AUDIENCE_BLINKIN_CHANNEL = 2;
+export enum RevHub {
+  TOTE = 0,
+  RED_HYDROGEN_TANK = 1,
+  BLUE_HYDROGEN_TANK = 2,
+}
+
+export type PwmDeviceFieldElement = "oxygenAccumulator" | "hydrogenTank" | "conversionButton" | "oxygenReleaser";
+
+export class PwmDevice {
+  public static readonly RED_OXYGEN_ACCUMULATOR_BLINKIN = new PwmDevice(RevHub.TOTE, 0, "oxygenAccumulator");
+  public static readonly RED_CONVERSION_BUTTON_BLINKIN = new PwmDevice(RevHub.TOTE, 1, "conversionButton");
+  public static readonly RED_OXYGEN_RELEASER_SERVO = new PwmDevice(RevHub.TOTE, 2, "oxygenReleaser");
+  public static readonly RED_HYDROGEN_TANK_BLINKIN = new PwmDevice(RevHub.RED_HYDROGEN_TANK, 0, "hydrogenTank");
+  public static readonly BLUE_OXYGEN_ACCUMULATOR_BLINKIN = new PwmDevice(RevHub.TOTE, 3, "oxygenAccumulator");
+  public static readonly BLUE_CONVERSION_BUTTON_BLINKIN = new PwmDevice(RevHub.TOTE, 4, "conversionButton");
+  public static readonly BLUE_OXYGEN_ACCUMULATOR_SERVO = new PwmDevice(RevHub.TOTE, 5, "oxygenReleaser");
+  public static readonly BLUE_HYDROGEN_TANK_BLINKIN = new PwmDevice(RevHub.BLUE_HYDROGEN_TANK, 0, "hydrogenTank");
+
+  public readonly hub: RevHub;
+  public readonly port: number;
+  public readonly fieldElement: PwmDeviceFieldElement;
+
+  private constructor(hub: RevHub, port: number, fieldElement: PwmDeviceFieldElement) {
+    this.hub = hub;
+    this.port = port;
+    this.fieldElement = fieldElement;
+  }
+}
+
+export interface PwmCommand {
+  device: PwmDevice;
+  pulseWidth_us: number | BlinkinPattern;
+}
+
+export function assemblePwmCommands(pwmCommands: PwmCommand[]): FieldControlPacket {
+  const hubMessages: HubMessage[] = [];
+
+  // Sort the commands for optimal visual synchronization.
+  // The most important thing is to have field elements of the same type grouped together.
+  pwmCommands.sort((a, b) => {
+    if (a.device.fieldElement == b.device.fieldElement) {
+      return 0; // Elements have the same priority
+    } else if (a.device.fieldElement == "hydrogenTank" || b.device.fieldElement == "hydrogenTank") {
+      // Hydrogen tanks are wireless, list them first
+      return a.device.fieldElement == "hydrogenTank" ? -1 : 1;
+    } else if (a.device.fieldElement == "oxygenAccumulator" || b.device.fieldElement == "oxygenAccumulator") {
+      // Oxygen accumulators are most prominent, list them next
+      return a.device.fieldElement == "oxygenAccumulator" ? -1 : 1;
+    } else if (a.device.fieldElement == "conversionButton" || b.device.fieldElement == "conversionButton") {
+      // Prioritize button visual feedback over moving the servo
+      return a.device.fieldElement == "conversionButton" ? -1 : 1;
+    } else {
+      /*
+       * We shouldn't be able to get to this point (though we can't convince the Typescript compiler of that),
+       * because the only way to get here is if both field elements are oxygenReleaser, and we've already covered
+       * the case where the field elements are the same.
+       */
+      return 0;
+    }
+  });
+
+  for (const command of pwmCommands) {
+    hubMessages.push({
+      hub: command.device.hub,
+      function: "servo",
+      parameters: {
+        port: command.device.port,
+        pulsewidth: command.pulseWidth_us,
+      }
+    });
+  }
+
+  return {
+    messages: hubMessages
+  }
+}
+
+export function createPacketToSetPatternEverywhere(pattern: BlinkinPattern, additionalCommands: PwmCommand[] = []): FieldControlPacket {
+  return assemblePwmCommands([
+    ...additionalCommands,
+    { device: PwmDevice.RED_OXYGEN_ACCUMULATOR_BLINKIN, pulseWidth_us: pattern },
+    { device: PwmDevice.RED_CONVERSION_BUTTON_BLINKIN, pulseWidth_us: pattern },
+    { device: PwmDevice.RED_HYDROGEN_TANK_BLINKIN, pulseWidth_us: pattern },
+    { device: PwmDevice.BLUE_OXYGEN_ACCUMULATOR_BLINKIN, pulseWidth_us: pattern },
+    { device: PwmDevice.BLUE_CONVERSION_BUTTON_BLINKIN, pulseWidth_us: pattern },
+    { device: PwmDevice.BLUE_HYDROGEN_TANK_BLINKIN, pulseWidth_us: pattern },
+  ])
+}
+
+export const RED_OXYGEN_ACCUMULATOR_HOLDING: PwmCommand = {
+  device: PwmDevice.RED_OXYGEN_RELEASER_SERVO,
+  pulseWidth_us: 500,
+};
+
+export const RED_OXYGEN_ACCUMULATOR_RELEASED: PwmCommand = {
+  device: PwmDevice.RED_OXYGEN_RELEASER_SERVO,
+  pulseWidth_us: 2500,
+};
+
+export const BLUE_OXYGEN_ACCUMULATOR_HOLDING: PwmCommand = {
+  device: PwmDevice.BLUE_OXYGEN_ACCUMULATOR_SERVO,
+  pulseWidth_us: 500,
+};
+
+export const BLUE_OXYGEN_ACCUMULATOR_RELEASED: PwmCommand = {
+  device: PwmDevice.BLUE_OXYGEN_ACCUMULATOR_SERVO,
+  pulseWidth_us: 2500,
+};
 
 export enum BlinkinPattern {
   COLOR_1_HB_FAST = 1535,
@@ -37,399 +142,47 @@ export enum BlinkinPattern {
   COLOR_YELLOW = 1845,
   COLOR_WAVES_RAINBOW = 1275,
   COLOR_WAVES_PARTY = 1285,
+  OFF = 1995,
+  STROBE_BLUE = 1455,
+  STROBE_RED = 1445,
 }
 
-export const LED_PRESTART: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_YELLOW
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_YELLOW
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_YELLOW
-      }
-    }
-  ]
-};
-export const LED_ALLCLEAR: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_GREEN
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_GREEN
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_GREEN
-      }
-    }
-  ]
-};
-export const LED_FIELDFAULT: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_RED
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_RED
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_RED
-      }
-    }
-  ]
-};
-export const LED_IDLE: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_WAVES_PARTY
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_WAVES_PARTY
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_WAVES_PARTY
-      }
-    }
-  ]
-};
-export const LED_COUNTDOWN: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_PURPLE
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_PURPLE
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_PURPLE
-      }
-    }
-  ]
-};
-export const LED_DISABLE: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: 1995
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: 1995
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: 1995
-      }
-    }
-  ]
-};
+export const FCS_IDLE = createPacketToSetPatternEverywhere(BlinkinPattern.COLOR_WAVES_PARTY);
+export const FCS_TURN_OFF_LIGHTS = createPacketToSetPatternEverywhere(BlinkinPattern.OFF);
+export const FCS_FIELD_FAULT = createPacketToSetPatternEverywhere(BlinkinPattern.COLOR_GREEN);
 
-export const LED_CARBON: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_WHITE
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_WHITE
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_WHITE
-      }
-    }
-  ]
-};
+// TODO: Make the oxygen releaser pulse widths a setting
+export const FCS_PREPARE_FIELD = createPacketToSetPatternEverywhere(
+    BlinkinPattern.COLOR_YELLOW,
+    [
+      RED_OXYGEN_ACCUMULATOR_HOLDING,
+      BLUE_OXYGEN_ACCUMULATOR_HOLDING,
+    ]
+);
+// TODO(Noah): Add a countdown
+export const FCS_MATCH_START = assemblePwmCommands([
+  RED_OXYGEN_ACCUMULATOR_HOLDING,
+  BLUE_OXYGEN_ACCUMULATOR_HOLDING,
+  { device: PwmDevice.RED_OXYGEN_ACCUMULATOR_BLINKIN, pulseWidth_us: BlinkinPattern.COLOR_RED },
+  { device: PwmDevice.RED_HYDROGEN_TANK_BLINKIN, pulseWidth_us: BlinkinPattern.COLOR_RED },
+  { device: PwmDevice.BLUE_OXYGEN_ACCUMULATOR_BLINKIN, pulseWidth_us: BlinkinPattern.COLOR_BLUE },
+  { device: PwmDevice.BLUE_HYDROGEN_TANK_BLINKIN, pulseWidth_us: BlinkinPattern.COLOR_BLUE },
+  { device: PwmDevice.RED_CONVERSION_BUTTON_BLINKIN, pulseWidth_us: BlinkinPattern.OFF },
+  { device: PwmDevice.BLUE_CONVERSION_BUTTON_BLINKIN, pulseWidth_us: BlinkinPattern.OFF },
+]);
+export const FCS_ENDGAME = assemblePwmCommands([
+  RED_OXYGEN_ACCUMULATOR_HOLDING,
+  BLUE_OXYGEN_ACCUMULATOR_HOLDING,
+  { device: PwmDevice.RED_OXYGEN_ACCUMULATOR_BLINKIN, pulseWidth_us: BlinkinPattern.STROBE_RED },
+  { device: PwmDevice.RED_HYDROGEN_TANK_BLINKIN, pulseWidth_us: BlinkinPattern.STROBE_RED },
+  { device: PwmDevice.RED_CONVERSION_BUTTON_BLINKIN, pulseWidth_us: BlinkinPattern.STROBE_RED },
+  { device: PwmDevice.BLUE_OXYGEN_ACCUMULATOR_BLINKIN, pulseWidth_us: BlinkinPattern.STROBE_BLUE },
+  { device: PwmDevice.BLUE_HYDROGEN_TANK_BLINKIN, pulseWidth_us: BlinkinPattern.STROBE_BLUE },
+  { device: PwmDevice.BLUE_CONVERSION_BUTTON_BLINKIN, pulseWidth_us: BlinkinPattern.STROBE_BLUE },
+]);
+export const FCS_ALL_CLEAR = createPacketToSetPatternEverywhere(BlinkinPattern.COLOR_GREEN);
 
-export const LED_COOPERTITION: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_PURPLE
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_PURPLE
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_PURPLE
-      }
-    }
-  ]
-};
-export const LED_COLOR1_HB_SLOW: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_1_HB_SLOW
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_1_HB_SLOW
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_1_HB_SLOW
-      }
-    }
-  ]
-};
-export const LED_COLOR2_HB_SLOW: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_2_HB_SLOW
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_2_HB_SLOW
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_2_HB_SLOW
-      }
-    }
-  ]
-};
-export const LED_COLOR1_HB_MED: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_1_HB_MED
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_1_HB_MED
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_1_HB_MED
-      }
-    }
-  ]
-};
-export const LED_COLOR2_HB_MED: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_2_HB_MED
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_2_HB_MED
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_2_HB_MED
-      }
-    }
-  ]
-};
-export const LED_COLOR1_HB_FAST: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_1_HB_FAST
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_1_HB_FAST
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_1_HB_FAST
-      }
-    }
-  ]
-};
-export const LED_COLOR2_HB_FAST: FieldControlPacket = {
-  messages: [
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_2_HB_FAST
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_2_HB_FAST
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_2_HB_FAST
-      }
-    }
-  ]
-};
+// TODO(Noah): Add optional field to FieldControlPacket that tells the device to keep polling the REV Hub digital inputs,
+//             and what to do when it sees certain inputs. The field should allow specifying PWM commands to execute and
+//             FCS messages to send. The device will stop polling when it receives another update command.
+//             Use this to handle the red and blue combined states during endgame.

--- a/lib/models/src/fcs/Packets.ts
+++ b/lib/models/src/fcs/Packets.ts
@@ -36,6 +36,7 @@ export enum BlinkinPattern {
   COLOR_WHITE = 1965,
   COLOR_YELLOW = 1845,
   COLOR_WAVES_RAINBOW = 1275,
+  COLOR_WAVES_PARTY = 1285,
 }
 
 export const LED_PRESTART: FieldControlPacket = {
@@ -129,7 +130,7 @@ export const LED_IDLE: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: RED_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_WAVES_RAINBOW
+        pulsewidth: BlinkinPattern.COLOR_WAVES_PARTY
       }
     },
     {
@@ -137,7 +138,7 @@ export const LED_IDLE: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_WAVES_RAINBOW
+        pulsewidth: BlinkinPattern.COLOR_WAVES_PARTY
       }
     },
     {
@@ -145,7 +146,7 @@ export const LED_IDLE: FieldControlPacket = {
       function: 'servo',
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: BlinkinPattern.COLOR_WAVES_RAINBOW
+        pulsewidth: BlinkinPattern.COLOR_WAVES_PARTY
       }
     }
   ]

--- a/lib/models/src/fcs/Packets.ts
+++ b/lib/models/src/fcs/Packets.ts
@@ -15,7 +15,6 @@ export const LED_COLOR_GREEN = 1885;
 export const LED_COLOR_RED = 1805;
 export const LED_COLOR_RAINBOW = 1275;
 export const LED_COLOR_FIRE = 1215;
-export const FULL_STRIP_PWM = 990;
 export const LED_COLOR_1_HB_SLOW = 1515;
 export const LED_COLOR_1_HB_MED = 1525;
 export const LED_COLOR_1_HB_FAST = 1535;
@@ -41,25 +40,6 @@ export const LED_COLOR_VIOLET = 1955;
 export const LED_COLOR_GRAY = 1975;
 export const LED_COLOR_DARK_GRAY = 1985;
 
-const calcPulseWidth = (ledLength: number): number => {
-  const maxPwm = 990;
-  const minPwm = 10;
-  const led1Pwm = 14;
-  const totalLedLength = 120;
-  return Math.min(
-    Math.floor((ledLength * (maxPwm - minPwm)) / totalLedLength + led1Pwm),
-    990
-  );
-};
-
-export const setLEDLength = (length: number): FieldControlPacket => {
-  const packet = LED_EMPTY;
-  const pulseWidth = calcPulseWidth(length);
-  packet.messages[0].parameters.pulsewidth = pulseWidth;
-  packet.messages[1].parameters.pulsewidth = pulseWidth;
-  packet.messages[2].parameters.pulsewidth = pulseWidth;
-  return packet;
-};
 export const setLEDPattern = (pulseWidth: number): FieldControlPacket => {
   const packet = LED_EMPTY;
   packet.messages[0].parameters.pulsewidth = pulseWidth;
@@ -155,30 +135,6 @@ export const LED_PRESTART: FieldControlPacket = {
         port: AUDIENCE_BLINKIN_CHANNEL,
         pulsewidth: LED_COLOR_YELLOW
       }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
-      }
     }
   ]
 };
@@ -206,30 +162,6 @@ export const LED_ALLCLEAR: FieldControlPacket = {
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
         pulsewidth: LED_COLOR_GREEN
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
       }
     }
   ]
@@ -259,30 +191,6 @@ export const LED_FIELDFAULT: FieldControlPacket = {
         port: AUDIENCE_BLINKIN_CHANNEL,
         pulsewidth: LED_COLOR_RED
       }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
-      }
     }
   ]
 };
@@ -311,30 +219,6 @@ export const LED_IDLE: FieldControlPacket = {
         port: AUDIENCE_BLINKIN_CHANNEL,
         pulsewidth: LED_COLOR_RAINBOW
       }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
-      }
     }
   ]
 };
@@ -362,30 +246,6 @@ export const LED_COUNTDOWN: FieldControlPacket = {
       parameters: {
         port: AUDIENCE_BLINKIN_CHANNEL,
         pulsewidth: LED_COLOR_PURPLE
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: RED_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: BLUE_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
-      }
-    },
-    {
-      hub: 0,
-      function: 'servo',
-      parameters: {
-        port: AUDIENCE_BLINKIN_CHANNEL,
-        pulsewidth: FULL_STRIP_PWM
       }
     }
   ]


### PR DESCRIPTION
This has not been tested yet, and some states are missing or have placeholders.

### Interesting changes
* Adds functions that provide a much more compact way to define field states
	* These functions also take care of sorting the commands in the most ideal order for the performance characteristics that matter most for this game.
* Instead of making the web browser responsible for triggering all FCS events, we trigger many of them within the realtime server process
	* This is done by exposing all broadcasted events from the `Match` room on an in-process `EventEmitter` as well, and having the `FCS` room listen for ones it cares about. See changes to `Match.ts`, `Rooms.ts`, and `FCS.ts`.
	* This enables the FCS to listen for endgame events, and also reduces the amount of cross-process (or even over-network) traffic.