### PR TITLE
Display match state in MatchStatus when a match is not in progress

### DIFF
--- a/front-end/src/apps/Scoring/components/MatchStatus/MatchStatus.tsx
+++ b/front-end/src/apps/Scoring/components/MatchStatus/MatchStatus.tsx
@@ -15,8 +15,15 @@ import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 
 const MatchStatus: FC = () => {
   const selectedMatch = useRecoilValue(matchInProgressAtom);
+  const matchState = useRecoilValue(matchStateAtom);
+  const [matchPhase, setMatchPhase] = useState(undefined as string | undefined);
 
-  const [mode, setMode] = useState('NOT READY');
+  let matchStatus: string;
+  if (matchState == MatchState.MATCH_IN_PROGRESS) {
+    matchStatus = matchPhase ?? 'MATCH STARTED';
+  } else {
+    matchStatus = MatchState[matchState].replaceAll('_', ' ');
+  }
 
   const [socket, connected] = useSocket();
 
@@ -27,7 +34,6 @@ const MatchStatus: FC = () => {
       socket?.on('match:auto', onMatchAuto);
       socket?.on('match:tele', onMatchTele);
       socket?.on('match:endgame', onMatchEndGame);
-      socket?.on('match:end', onMatchEnd);
       socket?.on('match:update', onMatchUpdate);
     }
   }, [connected, socket]);
@@ -37,18 +43,14 @@ const MatchStatus: FC = () => {
       socket?.removeListener('match:auto', onMatchAuto);
       socket?.removeListener('match:tele', onMatchTele);
       socket?.removeListener('match:endgame', onMatchEndGame);
-      socket?.removeListener('match:end', onMatchEnd);
       socket?.removeListener('match:update', onMatchUpdate);
     };
   }, []);
 
-  const onMatchAuto = () => setMode('AUTO');
-  const onMatchTele = () => setMode('TELEOP');
+  const onMatchAuto = () => setMatchPhase('AUTO');
+  const onMatchTele = () => setMatchPhase('TELEOP');
   const onMatchEndGame = useRecoilCallback(() => async () => {
-    setMode('ENDGAME');
-  });
-  const onMatchEnd = useRecoilCallback(() => async () => {
-    setMode('MATCH END');
+    setMatchPhase('ENDGAME');
   });
   const onMatchUpdate = useRecoilCallback(
     ({ set }) =>
@@ -77,7 +79,7 @@ const MatchStatus: FC = () => {
       <Divider />
       <Box sx={{ padding: (theme) => theme.spacing(2) }}>
         <Typography align='center' variant='h5'>
-          {mode}
+          {matchStatus}
         </Typography>
         <Typography align='center' variant='h5'>
           <MatchCountdown />

--- a/front-end/src/apps/Scoring/components/MatchStatus/MatchStatus.tsx
+++ b/front-end/src/apps/Scoring/components/MatchStatus/MatchStatus.tsx
@@ -4,7 +4,7 @@ import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import { useRecoilCallback, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { useSocket } from 'src/api/SocketProvider';
 import MatchCountdown from 'src/features/components/MatchCountdown/MatchCountdown';
 import { Match, MatchState } from '@toa-lib/models';
@@ -15,7 +15,6 @@ import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 
 const MatchStatus: FC = () => {
   const selectedMatch = useRecoilValue(matchInProgressAtom);
-  const setState = useSetRecoilState(matchStateAtom);
 
   const [mode, setMode] = useState('NOT READY');
 
@@ -50,7 +49,6 @@ const MatchStatus: FC = () => {
   });
   const onMatchEnd = useRecoilCallback(() => async () => {
     setMode('MATCH END');
-    setState(MatchState.MATCH_COMPLETE);
   });
   const onMatchUpdate = useRecoilCallback(
     ({ set }) =>

--- a/lib/models/src/MatchTimer.ts
+++ b/lib/models/src/MatchTimer.ts
@@ -55,21 +55,27 @@ export class MatchTimer extends EventEmitter {
 
   public start() {
     if (!this.inProgress()) {
+      let matchPhaseEvent: string;
       if (this.matchConfig.delayTime > 0) {
         this._mode = MatchMode.PRESTART;
         this._modeTimeLeft = this.matchConfig.delayTime;
+        matchPhaseEvent = "timer:prestart";
       } else if (this.matchConfig.autoTime > 0) {
         this._mode = MatchMode.AUTONOMOUS;
         this._modeTimeLeft = this.matchConfig.autoTime;
+        matchPhaseEvent = "timer:auto";
       } else if (this.matchConfig.transitionTime > 0) {
         this._mode = MatchMode.TRANSITION;
         this._modeTimeLeft = this.matchConfig.transitionTime;
+        matchPhaseEvent = "timer:transition";
       } else {
         this._mode = MatchMode.TELEOPERATED;
         this._modeTimeLeft = this.matchConfig.teleTime;
+        matchPhaseEvent = "timer:tele";
       }
       this._timeLeft = getMatchTime(this._matchConfig);
       this.emit('timer:start', this._timeLeft);
+      this.emit(matchPhaseEvent);
       this._timerID = setInterval(() => {
         this.tick();
       }, 1000);


### PR DESCRIPTION
Before, `NOT READY` would be displayed in the middle of the scoring page until the `MatchTimer` emitted its first event specifying which phase the match was in (which would not happen until the start of the second phase). 

Now, whenever a match is not currently in progress, the string version of the current `MatchState` is displayed, giving the operator more information.