### PR TITLE
Fix error handling on non-V8 platforms

### DIFF
--- a/lib/models/src/ApiErrors.ts
+++ b/lib/models/src/ApiErrors.ts
@@ -8,7 +8,9 @@ export class ApiResponseError extends Error {
   ) {
     super(err.message);
     this.name = `Invalid API Response from ${url} with code ${err.code}.`;
-    Error.captureStackTrace(this, ApiResponseError);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ApiResponseError);
+    }
   }
 }
 
@@ -21,7 +23,9 @@ export class ApiDatabaseError extends Error {
     } else {
       this.name = `Error while executing query in table ${table}.`;
     }
-    Error.captureStackTrace(this, ApiDatabaseError);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ApiDatabaseError);
+    }
   }
 }
 


### PR DESCRIPTION
Apparently I forgot to submit this one from awhile ago. Error.captureStackTrace() is a V8-specific API.