### PR TITLE
Configuration changes for FGC

### DIFF
--- a/back-end/realtime/src/rooms/FCS.ts
+++ b/back-end/realtime/src/rooms/FCS.ts
@@ -2,9 +2,8 @@ import { Server, Socket } from "socket.io";
 import {
   FCS_ENDGAME,
   FCS_FIELD_FAULT,
-  FCS_IDLE,
   FCS_INIT,
-  FCS_MATCH_START,
+  FCS_SOLID_ALLIANCE_COLORS,
   FCS_TURN_OFF_LIGHTS,
   FieldControlUpdatePacket
 } from "@toa-lib/models";
@@ -22,7 +21,7 @@ export default class FCS extends Room {
     });
 
     matchRoom.localEmitter.on("match:tele", () => {
-      this.broadcastFcsUpdate(FCS_MATCH_START);
+      this.broadcastFcsUpdate(FCS_SOLID_ALLIANCE_COLORS);
     });
 
     matchRoom.localEmitter.on("match:endgame", () => {
@@ -30,8 +29,7 @@ export default class FCS extends Room {
     });
 
     matchRoom.localEmitter.on("match:end", () => {
-      // TODO(Noah): Placeholder
-      this.broadcastFcsUpdate(FCS_IDLE);
+      this.broadcastFcsUpdate(FCS_SOLID_ALLIANCE_COLORS);
     });
 
     matchRoom.localEmitter.on("match:abort", () => {

--- a/back-end/realtime/src/rooms/FCS.ts
+++ b/back-end/realtime/src/rooms/FCS.ts
@@ -1,5 +1,13 @@
 import { Server, Socket } from "socket.io";
-import { FCS_ENDGAME, FCS_FIELD_FAULT, FCS_IDLE, FCS_INIT, FCS_MATCH_START, FieldControlUpdatePacket } from "@toa-lib/models";
+import {
+  FCS_ENDGAME,
+  FCS_FIELD_FAULT,
+  FCS_IDLE,
+  FCS_INIT,
+  FCS_MATCH_START,
+  FCS_TURN_OFF_LIGHTS,
+  FieldControlUpdatePacket
+} from "@toa-lib/models";
 import Room from "./Room.js";
 import Match from "./Match.js";
 
@@ -10,6 +18,10 @@ export default class FCS extends Room {
     super(server, "fcs");
 
     matchRoom.localEmitter.on("match:start", () => {
+      this.broadcastFcsUpdate(FCS_TURN_OFF_LIGHTS);
+    });
+
+    matchRoom.localEmitter.on("match:tele", () => {
       this.broadcastFcsUpdate(FCS_MATCH_START);
     });
 

--- a/front-end/src/apps/Scoring/components/MatchControl/FieldPrepButton.tsx
+++ b/front-end/src/apps/Scoring/components/MatchControl/FieldPrepButton.tsx
@@ -29,7 +29,7 @@ const FieldPrepButton: FC = () => {
       onClick={loading ? undefined : updateField}
       loading={loading}
     >
-      Prep (Not Used)
+      Prep Field
     </LoadingButton>
   );
 };

--- a/front-end/src/apps/Scoring/components/MatchStatus/MatchStatus.tsx
+++ b/front-end/src/apps/Scoring/components/MatchStatus/MatchStatus.tsx
@@ -82,7 +82,7 @@ const MatchStatus: FC = () => {
           {matchStatus}
         </Typography>
         <Typography align='center' variant='h5'>
-          <MatchCountdown />
+          <MatchCountdown audio />
         </Typography>
       </Box>
     </Paper>

--- a/lib/models/src/FieldControl.ts
+++ b/lib/models/src/FieldControl.ts
@@ -55,7 +55,6 @@ export interface FieldControlPacket<HubParametersType extends HubParameters<any,
   hubs: Record<number, HubParametersType>;
 }
 export type FieldControlInitPacket = FieldControlPacket<HubInitParameters>;
-// TODO(Noah): Set triggerOptions to null for most field packets
 export type FieldControlUpdatePacket = FieldControlPacket<HubUpdateParameters>;
 
 //-------------------------------------------

--- a/lib/models/src/MatchTimer.ts
+++ b/lib/models/src/MatchTimer.ts
@@ -10,7 +10,7 @@ export interface MatchConfiguration {
 
 export const FGC_MATCH_CONFIG: MatchConfiguration = {
   transitionTime: 0,
-  delayTime: 0,
+  delayTime: 3,
   autoTime: 0,
   teleTime: 150,
   endTime: 30

--- a/lib/models/src/MatchTimer.ts
+++ b/lib/models/src/MatchTimer.ts
@@ -48,7 +48,7 @@ export class MatchTimer extends EventEmitter {
 
     this._mode = MatchMode.RESET;
     this._timerID = null;
-    this._matchConfig = FRC_MATCH_CONFIG;
+    this._matchConfig = FGC_MATCH_CONFIG;
     this._timeLeft = getMatchTime(this._matchConfig);
     this._modeTimeLeft = this._matchConfig.delayTime;
   }

--- a/lib/models/src/MatchTimer.ts
+++ b/lib/models/src/MatchTimer.ts
@@ -10,7 +10,7 @@ export interface MatchConfiguration {
 
 export const FGC_MATCH_CONFIG: MatchConfiguration = {
   transitionTime: 0,
-  delayTime: 3,
+  delayTime: 0,
   autoTime: 0,
   teleTime: 150,
   endTime: 30

--- a/lib/models/src/fcs/Packets.ts
+++ b/lib/models/src/fcs/Packets.ts
@@ -287,19 +287,19 @@ export const FCS_MATCH_START = assemblePwmCommands([
 
 const FCS_RED_COMBINED = assemblePwmCommands([
   RED_OXYGEN_ACCUMULATOR_RELEASED,
-  { device: PwmDevice.RED_OXYGEN_ACCUMULATOR_BLINKIN, pulseWidth_us: BlinkinPattern.SPARKLE_COLOR_1_ON_COLOR_2 },
-  { device: PwmDevice.RED_HYDROGEN_TANK_BLINKIN, pulseWidth_us: BlinkinPattern.SPARKLE_COLOR_1_ON_COLOR_2 },
-  { device: PwmDevice.RED_CONVERSION_BUTTON_BLINKIN, pulseWidth_us: BlinkinPattern.SPARKLE_COLOR_1_ON_COLOR_2 },
+  { device: PwmDevice.RED_OXYGEN_ACCUMULATOR_BLINKIN, pulseWidth_us: BlinkinPattern.COLOR_1_2_GRADIENT },
+  { device: PwmDevice.RED_HYDROGEN_TANK_BLINKIN, pulseWidth_us: BlinkinPattern.COLOR_1_2_GRADIENT },
+  { device: PwmDevice.RED_CONVERSION_BUTTON_BLINKIN, pulseWidth_us: BlinkinPattern.COLOR_1_2_GRADIENT },
 ]);
 
 const FCS_BLUE_COMBINED = assemblePwmCommands([
   BLUE_OXYGEN_ACCUMULATOR_RELEASED,
-  { device: PwmDevice.BLUE_OXYGEN_ACCUMULATOR_BLINKIN, pulseWidth_us: BlinkinPattern.SPARKLE_COLOR_1_ON_COLOR_2 },
-  { device: PwmDevice.BLUE_HYDROGEN_TANK_BLINKIN, pulseWidth_us: BlinkinPattern.SPARKLE_COLOR_1_ON_COLOR_2 },
-  { device: PwmDevice.BLUE_CONVERSION_BUTTON_BLINKIN, pulseWidth_us: BlinkinPattern.SPARKLE_COLOR_1_ON_COLOR_2 },
+  { device: PwmDevice.BLUE_OXYGEN_ACCUMULATOR_BLINKIN, pulseWidth_us: BlinkinPattern.COLOR_1_2_GRADIENT },
+  { device: PwmDevice.BLUE_HYDROGEN_TANK_BLINKIN, pulseWidth_us: BlinkinPattern.COLOR_1_2_GRADIENT },
+  { device: PwmDevice.BLUE_CONVERSION_BUTTON_BLINKIN, pulseWidth_us: BlinkinPattern.COLOR_1_2_GRADIENT },
 ]);
 
-export const FCS_ENDGAME = createPacketToSetPatternEverywhere(BlinkinPattern.COLOR_1_2_GRADIENT);
+export const FCS_ENDGAME = createPacketToSetPatternEverywhere(BlinkinPattern.COLOR_1_HB_MED);
 FCS_ENDGAME.hubs[RevHub.TOTE]!.digitalInputs = [
   {
     channel: ConversionButtonDigitalChannel.RED,

--- a/lib/models/src/fcs/Packets.ts
+++ b/lib/models/src/fcs/Packets.ts
@@ -276,7 +276,7 @@ export const FCS_COUNTDOWN_3 = createPacketToSetPatternEverywhere(BlinkinPattern
 export const FCS_COUNTDOWN_2 = createPacketToSetPatternEverywhere(BlinkinPattern.COLOR_PINK);
 export const FCS_COUNTDOWN_1 = createPacketToSetPatternEverywhere(BlinkinPattern.COLOR_AQUA);
 
-export const FCS_MATCH_START = assemblePwmCommands([
+export const FCS_SOLID_ALLIANCE_COLORS = assemblePwmCommands([
   { device: PwmDevice.RED_OXYGEN_ACCUMULATOR_BLINKIN, pulseWidth_us: BlinkinPattern.COLOR_RED },
   { device: PwmDevice.RED_HYDROGEN_TANK_BLINKIN, pulseWidth_us: BlinkinPattern.COLOR_RED },
   { device: PwmDevice.BLUE_OXYGEN_ACCUMULATOR_BLINKIN, pulseWidth_us: BlinkinPattern.COLOR_BLUE },


### PR DESCRIPTION
I'm shelving the timer improvements for the moment, as testing showed the status quo to be better than I expected. I still plan to submit that PR for your future consideration, as it should be more accurate and robust.

This PR makes the following changes:
* Sets the match timer config to FGC,
* Changes the "Prep (Not Used)" button to say "Prep Field"
* Enables audio for the scoring computer
* Adds a three-second delay between match start and TeleOp
	* Strangely, it appears that as of the [v0.2-fgc-2022 tag](https://github.com/the-orange-alliance/project-ems/releases/tag/v0.2-fgc-2022), there was no such delay, and the `LED_COUNTDOWN` packet was unused, so I'm not sure how the countdown worked last year. Any enlightenment on that would be appreciated.
* Turns off the LEDs during the three-second delay