### PR TITLE
Fix Hydrogen Horizons scoring issues

### DIFF
--- a/front-end/src/seasons/HydrogenHorizons/referee/PenaltySheet.tsx
+++ b/front-end/src/seasons/HydrogenHorizons/referee/PenaltySheet.tsx
@@ -27,19 +27,6 @@ const PenaltySheet: FC<Props> = ({ alliance, onUpdate }) => {
     }
   };
 
-  const handleTechFoulChange = (majPen: number) => {
-    if (match) {
-      const newMatch = Object.assign({}, match);
-      if (alliance === 'red') {
-        newMatch.redMajPen = majPen;
-      } else {
-        newMatch.blueMinPen = majPen;
-      }
-      setMatch(newMatch);
-      onUpdate?.(newMatch);
-    }
-  };
-
   return (
     <Box
       sx={{
@@ -54,11 +41,6 @@ const PenaltySheet: FC<Props> = ({ alliance, onUpdate }) => {
       <NumberInput
         value={(alliance === 'red' ? match?.redMinPen : match?.blueMinPen) || 0}
         onChange={handleFoulChange}
-      />
-      <Typography variant='h6'>Tech Fouls</Typography>
-      <NumberInput
-        value={(alliance === 'red' ? match?.redMajPen : match?.blueMajPen) || 0}
-        onChange={handleTechFoulChange}
       />
     </Box>
   );

--- a/front-end/src/seasons/HydrogenHorizons/referee/ScoreSheet.tsx
+++ b/front-end/src/seasons/HydrogenHorizons/referee/ScoreSheet.tsx
@@ -72,7 +72,7 @@ const ScoreSheet: FC<RefereeScoreSheetProps> = ({ alliance }) => {
               station={p.station}
             />
           ))}
-          <PenaltySheet alliance='red' onUpdate={handleMatchUpdate} />
+          <PenaltySheet alliance={alliance} onUpdate={handleMatchUpdate} />
         </TabPanel>
       </Box>
     </Paper>

--- a/lib/models/src/seasons/HydrogenHorizons.ts
+++ b/lib/models/src/seasons/HydrogenHorizons.ts
@@ -317,9 +317,11 @@ export function calculateScore(match: Match<MatchDetails>): [number, number] {
     redTelePoints + proficiencyPoints + getCoopertitionPoints(details);
   const bluePoints =
     blueTelePoints + proficiencyPoints + getCoopertitionPoints(details);
+  const redPenalty = (match.redMinPen * 0.1) * redPoints;
+  const bluePenalty = (match.blueMinPen * 0.1) * bluePoints;
   return [
-    Math.ceil(redPoints * (1 - match.redMinPen * 0.1)),
-    Math.ceil(bluePoints * (1 - match.blueMinPen * 0.1))
+    Math.ceil(redPoints + bluePenalty),
+    Math.ceil(bluePoints + redPenalty)
   ];
 }
 

--- a/lib/models/src/seasons/HydrogenHorizons.ts
+++ b/lib/models/src/seasons/HydrogenHorizons.ts
@@ -248,6 +248,7 @@ export function calculatePlayoffsRank(
       };
 
       if (participant.cardStatus === 2) {
+        ranking.played += 1;
         rankingMap.set(participant.teamKey, ranking);
         continue;
       }
@@ -258,7 +259,6 @@ export function calculatePlayoffsRank(
         ranking.rankingScore += match.blueScore;
       }
 
-      ranking.played += 1;
       rankingMap.set(participant.teamKey, ranking);
     }
   }

--- a/lib/models/src/seasons/HydrogenHorizons.ts
+++ b/lib/models/src/seasons/HydrogenHorizons.ts
@@ -128,7 +128,7 @@ function calculateRankings(
       if (participant.station < 20) {
         // Red Alliance
         if (participant.cardStatus === 2) {
-          scoresMap.set(participant.teamKey, [...scores, match.redScore]);
+          scoresMap.set(participant.teamKey, [...scores, 0]);
           ranking.losses = ranking.losses + 1;
         } else {
           scoresMap.set(participant.teamKey, [...scores, match.redScore]);
@@ -148,7 +148,7 @@ function calculateRankings(
       if (participant.station >= 20) {
         // Blue Alliance
         if (participant.cardStatus === 2) {
-          scoresMap.set(participant.teamKey, [...scores, match.blueScore]);
+          scoresMap.set(participant.teamKey, [...scores, 0]);
           ranking.losses = ranking.losses + 1;
         } else {
           scoresMap.set(participant.teamKey, [...scores, match.blueScore]);

--- a/lib/models/src/seasons/HydrogenHorizons.ts
+++ b/lib/models/src/seasons/HydrogenHorizons.ts
@@ -304,7 +304,7 @@ export function calculateScore(match: Match<MatchDetails>): [number, number] {
     (details.redHydrogenPoints + details.redOxygenPoints) *
     getMultiplier(details.redAlignment);
   const blueTelePoints =
-    (details.blueHydrogenPoints + details.blueHydrogenPoints) *
+    (details.blueHydrogenPoints + details.blueOxygenPoints) *
     getMultiplier(details.blueAlignment);
   const proficiencyPoints =
     getProficiencyPoints(details.redOneProficiency) +


### PR DESCRIPTION
* Blue's hydrogen points were being counted twice, while their oxygen points were being ignored
* Blue fouls were being assigned to red
* Penalty points were being deducted instead of given to the opposing alliance (which is what the game manual says should happen)
* The ref app included a spot to assign tech fouls, which do not exist in Hydrogen Horizons
* Red-carded teams were being assigned points for the match
* Alliances that got a red card in the playoffs were recorded as if they didn't play that match (please review commit [1638be5](https://github.com/the-orange-alliance/project-ems/pull/86/commits/1638be558f3bae87596107cabd6d483d354c65c2) to make sure that this was a correct change).