### PR TITLE
Fix usages of full country name where the country code should be used

### DIFF
--- a/front-end/src/apps/AudienceDisplay/displays/fgc_2023/MatchPlay/MatchPlay.tsx
+++ b/front-end/src/apps/AudienceDisplay/displays/fgc_2023/MatchPlay/MatchPlay.tsx
@@ -23,7 +23,7 @@ const LeftParticipant: FC<{ participant: MatchParticipant }> = ({
     <div className='team'>
       <CardStatus cardStatus={participant.cardStatus} />
       <div className='team-name-left-p'>
-        <span>{participant.team?.country}</span>
+        <span>{participant.team?.countryCode}</span>
       </div>
       <div className='team-flag'>
         <span

--- a/front-end/src/apps/AudienceDisplay/displays/fgc_2023/MatchPlay/MatchPlay.tsx
+++ b/front-end/src/apps/AudienceDisplay/displays/fgc_2023/MatchPlay/MatchPlay.tsx
@@ -50,7 +50,7 @@ const RightParticipant: FC<{
         />
       </div>
       <div className='team-name-right-p'>
-        <span>{participant.team?.country}</span>
+        <span>{participant.team?.countryCode}</span>
       </div>
       <CardStatus cardStatus={participant.cardStatus} />
     </div>

--- a/front-end/src/apps/AudienceDisplay/displays/fgc_2023/MatchPreview/MatchPreview.tsx
+++ b/front-end/src/apps/AudienceDisplay/displays/fgc_2023/MatchPreview/MatchPreview.tsx
@@ -34,7 +34,8 @@ const Participant: FC<{ participant: MatchParticipant; ranking?: Ranking }> = ({
         />
       </div>
       <div className={'pre-match-team'}>
-        ({participant?.team?.country})&nbsp;{participant?.team?.teamNameLong}
+        ({participant?.team?.countryCode})&nbsp;
+        {participant?.team?.teamNameLong}
       </div>
       <div className='pre-match-rank'>
         {ranking &&


### PR DESCRIPTION
On the `MatchPlay` display, the display was not big enough to fit the full country name.

On the `MatchPreview` display, the full country name was displayed in parentheses next to the long team name, which for FGC, will be the same. Displaying the country code in parentheses helps everyone keep track of which team is which on the smaller `MatchPlay` display.