### PR TITLE
Pre-Setup Bugfixes

### DIFF
--- a/back-end/realtime/src/rooms/Match.ts
+++ b/back-end/realtime/src/rooms/Match.ts
@@ -47,7 +47,8 @@ export default class Match extends Room {
     // These are in case of mid-match disconnect/reconnects
     if (
       this.state >= MatchState.PRESTART_COMPLETE &&
-      this.state !== MatchState.MATCH_COMPLETE &&
+      this.state !== MatchState.MATCH_COMPLETE && // we never actually get into this state (in the socket server, anyway)
+      this.state !== MatchState.RESULTS_COMMITTED && // so instead we'll stop prestarting people here instead
       this.key &&
       !this.timer.inProgress()
     ) {

--- a/front-end/src/apps/Settings/index.tsx
+++ b/front-end/src/apps/Settings/index.tsx
@@ -16,6 +16,7 @@ import {
 } from 'src/stores/recoil';
 import { Tournament } from '@toa-lib/models';
 import FrcFmsSettingsTab from './tabs/frc-fms';
+import { ViewReturn } from 'src/components/buttons/view-return';
 // import FrcFmsSettingsTab from './tabs/frc-fms';
 
 export const SettingsApp: FC = () => {
@@ -50,6 +51,7 @@ export const SettingsApp: FC = () => {
       }
     >
       <Paper sx={{ marginBottom: (theme) => theme.spacing(8) }}>
+        <ViewReturn title='Home' href={`/${eventKey}`} sx={{ m: 1 }} />
         {/* Tabs */}
         <TabContext value={tab}>
           <TabList onChange={(e, t) => setTab(t)}>

--- a/front-end/src/apps/Settings/index.tsx
+++ b/front-end/src/apps/Settings/index.tsx
@@ -75,6 +75,9 @@ export const SettingsApp: FC = () => {
             <FrcFmsSettingsTab />
           </TabPanel>
         </TabContext>
+        <Typography variant='caption' sx={{ m: 1 }}>
+          ** Settings Save Automatically
+        </Typography>
       </Paper>
     </PaperLayout>
   );

--- a/front-end/src/apps/jb-app/jb-app.tsx
+++ b/front-end/src/apps/jb-app/jb-app.tsx
@@ -1,6 +1,6 @@
 import { FC, useState, useEffect } from 'react';
 import { DateTime } from 'luxon';
-import './JBApp.less';
+import './jb-app.less';
 import { ChromaLayout } from 'src/layouts/chroma-layout';
 import { useRecoilValue } from 'recoil';
 import { MatchTimer } from 'src/components/util/match-timer';

--- a/front-end/src/apps/scorekeeper/hooks/use-commit-scores.ts
+++ b/front-end/src/apps/scorekeeper/hooks/use-commit-scores.ts
@@ -19,7 +19,10 @@ import {
   matchOccurringAtom,
   socketConnectedAtom
 } from 'src/stores/recoil';
-import { patchWholeMatch, useMatchesForTournament } from 'src/api/use-match-data';
+import {
+  patchWholeMatch,
+  useMatchesForTournament
+} from 'src/api/use-match-data';
 import { recalculateRankings } from 'src/api/use-ranking-data';
 import { sendAllClear, sendCommitScores } from 'src/api/use-socket';
 import { useSeasonFieldControl } from 'src/hooks/use-season-components';
@@ -29,7 +32,10 @@ export const useCommitScoresCallback = () => {
   const fieldControl = useSeasonFieldControl();
   const eventKey = useRecoilValue(currentEventKeyAtom);
   const tournamentKey = useRecoilValue(currentTournamentKeyAtom);
-  const { data: matches, mutate: setMatches } = useMatchesForTournament(eventKey, tournamentKey);
+  const { data: matches, mutate: setMatches } = useMatchesForTournament(
+    eventKey,
+    tournamentKey
+  );
 
   return useRecoilCallback(
     ({ snapshot, set }) =>
@@ -45,7 +51,7 @@ export const useCommitScoresCallback = () => {
         if (!match) {
           throw new Error('Attempted to commit scores when there is no match.');
         }
-        const pending = { ...match };
+        const pending = { ...match, details: { ...match.details } };
         // Update the result if it hasn't been set yet
         if (pending.result < 0) {
           pending.result =

--- a/front-end/src/apps/scorekeeper/hooks/use-next-unplayed-match.ts
+++ b/front-end/src/apps/scorekeeper/hooks/use-next-unplayed-match.ts
@@ -1,0 +1,44 @@
+import { useRecoilCallback, useRecoilValue } from 'recoil';
+import {
+  currentEventKeyAtom,
+  currentMatchIdAtom,
+  currentTournamentKeyAtom,
+  matchOccurringAtom
+} from 'src/stores/recoil';
+import { useMatchesForTournament } from 'src/api/use-match-data';
+import { useActiveFieldNumbers } from 'src/components/sync-effects/sync-fields-to-recoil';
+
+export const useNextUnplayedMatch = () => {
+  const eventKey = useRecoilValue(currentEventKeyAtom);
+  const tournamentKey = useRecoilValue(currentTournamentKeyAtom);
+  const { data: matches } = useMatchesForTournament(eventKey, tournamentKey);
+  const [activeFields] = useActiveFieldNumbers();
+
+  return useRecoilCallback(
+    ({ snapshot }) =>
+      async () => {
+        const match = await snapshot.getPromise(matchOccurringAtom);
+
+        if (!match) {
+          return null;
+        }
+
+        // Try to find the next match and select it
+        if (matches) {
+          const ourMatches = matches
+            .filter((m) => activeFields.includes(m.fieldNumber))
+            .sort((a, b) => a.id - b.id);
+
+          // Find the next match that hasn't had results posted
+          const index = ourMatches.findIndex(
+            (m) => m.id >= match.id && m.result < 0
+          );
+          if (ourMatches[index]) {
+            return ourMatches[index];
+          }
+        }
+        return null;
+      },
+    [matches, eventKey, tournamentKey, activeFields]
+  );
+};

--- a/front-end/src/apps/scorekeeper/hooks/use-post-results.ts
+++ b/front-end/src/apps/scorekeeper/hooks/use-post-results.ts
@@ -1,18 +1,24 @@
 import { MatchState } from '@toa-lib/models';
-import { useRecoilCallback } from 'recoil';
+import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { useMatchControl } from './use-match-control';
 import { sendPostResults } from 'src/api/use-socket';
 import {
+  currentEventKeyAtom,
   currentMatchIdAtom,
+  currentTournamentKeyAtom,
   matchOccurringAtom,
   socketConnectedAtom
 } from 'src/stores/recoil';
 import { matchesByEventKeyAtomFam } from 'src/stores/recoil';
 import { useSeasonFieldControl } from 'src/hooks/use-season-components';
+import { useMatchesForTournament } from 'src/api/use-match-data';
 
 export const usePostResultsCallback = () => {
   const { canPostResults, setState } = useMatchControl();
   const fieldControl = useSeasonFieldControl();
+  const eventKey = useRecoilValue(currentEventKeyAtom);
+  const tournamentKey = useRecoilValue(currentTournamentKeyAtom);
+  const { data: matches } = useMatchesForTournament(eventKey, tournamentKey);
   return useRecoilCallback(
     ({ snapshot, set }) =>
       async () => {
@@ -27,20 +33,22 @@ export const usePostResultsCallback = () => {
         if (!match) {
           throw new Error('Attempted to psot results when there is no match.');
         }
-        const matches = await snapshot.getPromise(
-          matchesByEventKeyAtomFam(match.eventKey)
-        );
-        // TODO - Filter by matches selected via fields
-        const index = matches.findIndex((m) => m.id === match.id);
+
         // TODO - Sync results to server
-        if (matches[index + 1]) {
-          set(currentMatchIdAtom, matches[index + 1].id);
-          set(matchOccurringAtom, matches[index + 1]);
+
+        // Try to find the next match and select it
+        if (matches) {
+          // TODO - Filter by matches selected via fields
+          const index = matches.findIndex((m) => m.id === match.id);
+          if (matches[index + 1]) {
+            set(currentMatchIdAtom, matches[index + 1].id);
+            set(matchOccurringAtom, matches[index + 1]);
+          }
         }
         fieldControl?.postResultsForField?.();
         sendPostResults();
         setState(MatchState.RESULTS_POSTED);
       },
-    [canPostResults, setState]
+    [canPostResults, setState, matches, eventKey, tournamentKey]
   );
 };

--- a/front-end/src/apps/scorekeeper/match-control/prestart-button.tsx
+++ b/front-end/src/apps/scorekeeper/match-control/prestart-button.tsx
@@ -7,14 +7,27 @@ import {
 } from '../hooks/use-prestart';
 import { useSnackbar } from 'src/hooks/use-snackbar';
 import { LoadingButton } from '@mui/lab';
+import { ReplayDialog } from 'src/components/dialogs/replay-dialog';
+import { useModal } from '@ebay/nice-modal-react';
+import { useRecoilValue } from 'recoil';
+import { matchOccurringAtom } from 'src/stores/recoil';
+import { RESULT_NOT_PLAYED } from '@toa-lib/models';
 
 export const PrestartButton: FC = () => {
   const [loading, setLoading] = useState(false);
+  const replayDialog = useModal(ReplayDialog);
+  const match = useRecoilValue(matchOccurringAtom);
   const { canPrestart, canCancelPrestart } = useMatchControl();
   const { showSnackbar } = useSnackbar();
   const prestart = usePrestartCallback();
   const cancelPrestart = useCancelPrestartCallback();
   const sendPrestart = async () => {
+    if (match?.result !== RESULT_NOT_PLAYED) {
+      const doReplay = await replayDialog.show();
+      if (!doReplay) {
+        return;
+      }
+    }
     setLoading(true);
     try {
       await prestart();
@@ -33,26 +46,30 @@ export const PrestartButton: FC = () => {
       showSnackbar('Error while cancelling prestart', error);
     }
   };
-  return canPrestart ? (
-    <LoadingButton
-      fullWidth
-      color='warning'
-      variant='contained'
-      onClick={sendPrestart}
-      disabled={!canPrestart || loading}
-      loading={loading}
-    >
-      Prestart
-    </LoadingButton>
-  ) : (
-    <Button
-      fullWidth
-      color='error'
-      variant='contained'
-      onClick={sendCancelPrestart}
-      disabled={!canCancelPrestart}
-    >
-      Cancel Prestart
-    </Button>
+  return (
+    <>
+      {canPrestart ? (
+        <LoadingButton
+          fullWidth
+          color='warning'
+          variant='contained'
+          onClick={sendPrestart}
+          disabled={!canPrestart || loading}
+          loading={loading}
+        >
+          Prestart
+        </LoadingButton>
+      ) : (
+        <Button
+          fullWidth
+          color='error'
+          variant='contained'
+          onClick={sendCancelPrestart}
+          disabled={!canCancelPrestart}
+        >
+          Cancel Prestart
+        </Button>
+      )}
+    </>
   );
 };

--- a/front-end/src/apps/scorekeeper/tabs/scorekeeper-tabs.tsx
+++ b/front-end/src/apps/scorekeeper/tabs/scorekeeper-tabs.tsx
@@ -11,6 +11,7 @@ import { currentMatchIdAtom, matchOccurringAtom } from 'src/stores/recoil';
 import { useMatchControl } from '../hooks/use-match-control';
 import { MatchState } from '@toa-lib/models';
 import { ScorekeeperDetails } from './scorekeeper-details';
+import { useActiveFieldNumbers } from 'src/components/sync-effects/sync-fields-to-recoil';
 
 interface Props {
   eventKey?: string;
@@ -24,6 +25,7 @@ export const ScorekeeperTabs: FC<Props> = ({ eventKey }) => {
   const [matchId, setMatchId] = useRecoilState(currentMatchIdAtom);
   const [value, setValue] = useState(0);
   const setMatchOccurring = useSetRecoilState(matchOccurringAtom);
+  const [activeFields, setActiveFields] = useActiveFieldNumbers();
 
   const { data: tournaments } = useTournamentsForEvent(eventKey);
   const { data: matches } = useMatchesForTournament(eventKey, tournamentKey);
@@ -55,7 +57,7 @@ export const ScorekeeperTabs: FC<Props> = ({ eventKey }) => {
       <Divider />
       <TabPanel value={value} index={0}>
         <ScorekeeperMatches
-          matches={matches}
+          matches={matches?.filter((m) => activeFields.includes(m.fieldNumber))}
           teams={teams}
           tournaments={tournaments}
           tournamentKey={tournamentKey}

--- a/front-end/src/components/dialogs/replay-dialog.tsx
+++ b/front-end/src/components/dialogs/replay-dialog.tsx
@@ -1,0 +1,45 @@
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import { create, useModal, muiDialogV5 } from '@ebay/nice-modal-react';
+
+export const ReplayDialog = create(() => {
+  const handleContinue = () => {
+    modal.resolve(true);
+    modal.hide();
+  };
+  const modal = useModal();
+  const handleClose = () => {
+    modal.resolve(false);
+    modal.hide();
+  };
+  return (
+    <Dialog {...muiDialogV5(modal)} onClose={handleClose}>
+      <DialogTitle
+        sx={{
+          backgroundColor: (theme) => theme.palette.primary.main,
+          color: (theme) => theme.palette.common.white,
+          marginBottom: (theme) => theme.spacing(2)
+        }}
+      >
+        Replay Match
+      </DialogTitle>
+      <DialogContentText sx={{ padding: (theme) => theme.spacing(2) }}>
+        <p>
+          It looks like this match has already been played.  By continuing, you will replay the match and overwrite the previous results, which is an irreversible action.
+        </p>
+        <p>Are you sure you want to replay the match?</p>
+      </DialogContentText>
+      <DialogActions>
+        <Button onClick={handleContinue}>
+          Yes, I want to replay the match
+        </Button>
+        <Button onClick={handleClose} color='error'>
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+});

--- a/front-end/src/components/sync-effects/sync-fields-to-recoil.tsx
+++ b/front-end/src/components/sync-effects/sync-fields-to-recoil.tsx
@@ -52,3 +52,21 @@ export const useActiveFields = () => {
   };
   return [activeFields, set] as const;
 };
+
+export const useActiveFieldNumbers = () => {
+  const [activeFields, setActiveFields] = useRecoilState(activeFieldsAtom);
+  const tournament = useCurrentTournament();
+  const [, setLocalStorage] = useLocalStorage(
+    `${tournament?.eventKey}-${tournament?.tournamentKey}`,
+    tournament?.fields
+  );
+  // Convert the fields to numbers
+  const numbers = activeFields.map((f) => (tournament?.fields.indexOf(f) ?? -2) + 1);
+  const set = (fields: number[]) => {
+    if (!tournament) return;
+    const names = fields.map((f) => tournament.fields[f - 1]);
+    setActiveFields(names);
+    setLocalStorage(names);
+  };
+  return [numbers, set] as const;
+};

--- a/front-end/src/components/sync-effects/sync-fields-to-recoil.tsx
+++ b/front-end/src/components/sync-effects/sync-fields-to-recoil.tsx
@@ -7,7 +7,7 @@ import useLocalStorage from 'src/stores/local-storage';
 export const useSyncFieldsToRecoil = () => {
   const setActiveFields = useSetRecoilState(activeFieldsAtom);
   const tournament = useCurrentTournament();
-  const [localStorage, setLocalStorage] = useLocalStorage(
+  const [localStorageState, setLocalStorage] = useLocalStorage(
     `${tournament?.eventKey}-${tournament?.tournamentKey}`,
     tournament?.fields
   );
@@ -15,15 +15,25 @@ export const useSyncFieldsToRecoil = () => {
   // Set active fields whenever the tournament changes.1
   useEffect(() => {
     if (!tournament) return;
-    if (localStorage) {
-      console.log('Setting active fields from local storage:', localStorage);
-      setActiveFields(localStorage);
+
+    // This is dumb, but resolves this issue for now.  Currently, the tournament resolves, 
+    // but the localStorageState doesn't update fast enough.
+    // So, we'll fetch it manually and double-check JUST in case...
+    const stored = localStorage.getItem(
+      `${tournament.eventKey}-${tournament.tournamentKey}`
+    );
+    if (localStorageState) {
+      console.log('Setting active fields from local storage state:', localStorage);
+      setActiveFields(localStorageState);
+    } else if (stored) {
+      console.log('Setting active fields from local storage (manual):', stored);
+      setActiveFields(JSON.parse(stored));
     } else {
-      console.log('Setting active fields from tournament:', localStorage);
+      console.log('Setting active fields from tournament:', tournament.fields);
       setActiveFields(tournament.fields);
       setLocalStorage(tournament.fields);
     }
-  }, [tournament]);
+  }, [tournament, localStorage]);
 
   return null;
 };

--- a/front-end/src/seasons/ChargedUp/referee/TeamSheet.tsx
+++ b/front-end/src/seasons/ChargedUp/referee/TeamSheet.tsx
@@ -5,7 +5,7 @@ import ToggleButton from '@mui/material/ToggleButton';
 import Typography from '@mui/material/Typography';
 import { matchOccurringAtom } from '@stores/recoil';
 import { useSocket } from 'src/api/use-socket';
-import { MatchSocketEvent } from '@toa-lib/models';
+import { MatchParticipant, MatchSocketEvent } from '@toa-lib/models';
 
 interface Props {
   station: number;
@@ -13,10 +13,8 @@ interface Props {
 
 const TeamSheet: FC<Props> = ({ station }) => {
   const [socket] = useSocket();
-  const match = useRecoilValue(matchOccurringAtom);
-  const [participant, setParticipant] = useRecoilState(
-    matchInProgressParticipantsByStationSelectorFam(station)
-  );
+  const [match, setMatch] = useRecoilState(matchOccurringAtom);
+  const participant = match?.participants?.find((p) => p.station === station);
 
   const [updateReady, setUpdateReady] = useState(false);
 
@@ -26,6 +24,22 @@ const TeamSheet: FC<Props> = ({ station }) => {
       setUpdateReady(false);
     }
   }, [updateReady]);
+
+  const setParticipant = (participant: MatchParticipant) => {
+    if (match && match.participants) {
+      setMatch(
+        Object.assign(
+          {},
+          {
+            ...match,
+            participants: match.participants.map((p) =>
+              p.station === station ? participant : p
+            )
+          }
+        )
+      );
+    }
+  };
 
   const handleCardChange = (cardStatus: number) => {
     if (participant) {

--- a/front-end/src/seasons/Crescendo/referee/TeamSheet.tsx
+++ b/front-end/src/seasons/Crescendo/referee/TeamSheet.tsx
@@ -1,11 +1,11 @@
 import { FC, useState, useEffect } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import Box from '@mui/material/Box';
 import ToggleButton from '@mui/material/ToggleButton';
 import Typography from '@mui/material/Typography';
 import { matchOccurringAtom } from '@stores/recoil';
 import { useSocket } from 'src/api/use-socket';
-import { MatchSocketEvent } from '@toa-lib/models';
+import { MatchParticipant, MatchSocketEvent } from '@toa-lib/models';
 
 interface Props {
   station: number;
@@ -13,10 +13,8 @@ interface Props {
 
 const TeamSheet: FC<Props> = ({ station }) => {
   const [socket] = useSocket();
-  const match = useRecoilValue(matchOccurringAtom);
-  const [participant, setParticipant] = useRecoilState(
-    matchInProgressParticipantsByStationSelectorFam(station)
-  );
+  const [match, setMatch] = useRecoilState(matchOccurringAtom);
+  const participant = match?.participants?.find((p) => p.station === station);
 
   const [updateReady, setUpdateReady] = useState(false);
 
@@ -26,6 +24,22 @@ const TeamSheet: FC<Props> = ({ station }) => {
       setUpdateReady(false);
     }
   }, [updateReady]);
+
+  const setParticipant = (participant: MatchParticipant) => {
+    if (match && match.participants) {
+      setMatch(
+        Object.assign(
+          {},
+          {
+            ...match,
+            participants: match.participants.map((p) =>
+              p.station === station ? participant : p
+            )
+          }
+        )
+      );
+    }
+  };
 
   const handleCardChange = (cardStatus: number) => {
     if (participant) {

--- a/front-end/src/seasons/fgc-2024/nexus-sheets/nexus-scoresheet.tsx
+++ b/front-end/src/seasons/fgc-2024/nexus-sheets/nexus-scoresheet.tsx
@@ -49,7 +49,7 @@ const NexusScoresheet: React.FC<NexusScoresheetProps> = ({
     newState: NexusGoalState
   ) => {
     if (!onChange) return;
-    onChange({ ...state, [goal]: newState });
+    onChange({ ...state, [goal]: newState } as AllianceNexusGoalState);
   };
 
   return (


### PR DESCRIPTION
This fixes a bunch of bugs I found while testing the match play sequence

 - Fix scores not "saving" properly (they were, but the 'results' key was never getting calculated, so the match appeared unplayed in most places)
 - Added functionality to update the scorekeeper match table with the score after committing a match
 - Fix auto-selecting next match not having participants (or details) in the match object
 - Fix bug where the "Field Control" setting in settings wasn't persisting through refreshes
 - Add home button and disclaimer text ("Settings save automatically") to event settings page
 - Fix (again) another issue PATCHing match details
 - Autoselect next match based on the configured fields selected in settings, as well as the results of the matches (so after a replayed match, it will jump to the next UNPLAYED match rather than the next match on that field)
 - Only show matches for the fields selected in settings in the scorekeeper match table
 - Add warning dialog before prestarting a match that has already been played
 -  Stop socket server from emitting prestart even after scores have been committed
    - The socket server never gets into the state of results posted, so we'll stop emitting the prestart after the scores have been commited.  This allows the scorekeeper to refresh the page without it auto-grabbing the last played match blindly
 - Fix some TS issues preventing the build from building successfully 